### PR TITLE
Add support for audio files multimodal data ingestion

### DIFF
--- a/comps/dataprep/multimodal/redis/langchain/README.md
+++ b/comps/dataprep/multimodal/redis/langchain/README.md
@@ -3,6 +3,7 @@
 This `dataprep` microservice accepts the following from the user and ingests them into a Redis vectorstore:
 * Videos (mp4 files) and their transcripts (optional)
 * Images (gif, jpg, jpeg, and png files)
+* Audio (wav files)
 
 ## 🚀1. Start Microservice with Python（Option 1）
 
@@ -146,11 +147,11 @@ curl -X POST \
 
 ### 4.2 Consume _generate_transcripts_ API
 
-**Use case:** This API should be used when a video has meaningful audio or recognizable speech but its transcript file is not available.
+**Use case:** This API should be used when a video has meaningful audio or recognizable speech but its transcript file is not available, or for audio files with speech.
 
-In this use case, this microservice will use [`whisper`](https://openai.com/index/whisper/) model to generate the `.vtt` transcript for the video.
+In this use case, this microservice will use [`whisper`](https://openai.com/index/whisper/) model to generate the `.vtt` transcript for the video or audio files.
 
-#### Single video upload
+#### Single file upload
 
 ```bash
 curl -X POST \
@@ -159,13 +160,14 @@ curl -X POST \
     http://localhost:6007/v1/generate_transcripts
 ```
 
-#### Multiple video upload
+#### Multiple file upload
 
 ```bash
 curl -X POST \
     -H "Content-Type: multipart/form-data" \
     -F "files=@./video1.mp4" \
     -F "files=@./video2.mp4" \
+    -F "files=@./audio1.wav" \
     http://localhost:6007/v1/generate_transcripts
 ```
 

--- a/comps/dataprep/multimodal/redis/langchain/multimodal_utils.py
+++ b/comps/dataprep/multimodal/redis/langchain/multimodal_utils.py
@@ -128,6 +128,43 @@ def convert_img_to_base64(image):
     return encoded_string.decode()
 
 
+def generate_annotations_from_transcript(file_id: str, file_path: str, vtt_path: str, output_dir: str):
+    """ Generates an annotations.json from the transcript file """
+
+    # Set up location to store frames and annotations
+    os.makedirs(output_dir, exist_ok=True)
+
+    # read captions file
+    captions = webvtt.read(vtt_path)
+
+    annotations = []
+    for idx, caption in enumerate(captions):
+        start_time = str2time(caption.start)
+        end_time = str2time(caption.end)
+        mid_time = (end_time + start_time) / 2
+        mid_time_ms = mid_time * 1000
+        text = caption.text.replace("\n", " ")
+
+        # Create annotations for frame from transcripts with an empty image
+        annotations.append(
+            {
+                "video_id": file_id,
+                "video_name": os.path.basename(file_path),
+                "b64_img_str": "",
+                "caption": text,
+                "time": mid_time_ms,
+                "frame_no": 0,
+                "sub_video_id": idx,
+            }
+        )
+
+    # Save transcript annotations as json file for further processing
+    with open(os.path.join(output_dir, "annotations.json"), "w") as f:
+        json.dump(annotations, f)
+
+    return annotations
+
+
 def extract_frames_and_annotations_from_transcripts(video_id: str, video_path: str, vtt_path: str, output_dir: str):
     """Extract frames (.png) and annotations (.json) from video file (.mp4) and captions file (.vtt)"""
     # Set up location to store frames and annotations

--- a/comps/dataprep/multimodal/redis/langchain/prepare_videodoc_redis.py
+++ b/comps/dataprep/multimodal/redis/langchain/prepare_videodoc_redis.py
@@ -23,6 +23,7 @@ from multimodal_utils import (
     extract_frames_and_annotations_from_transcripts,
     extract_frames_and_generate_captions,
     extract_transcript_from_audio,
+    generate_annotations_from_transcript,
     generate_id,
     load_json_file,
     load_whisper_model,
@@ -44,7 +45,7 @@ class MultimodalRedis(Redis):
     def from_text_image_pairs_return_keys(
         cls: Type[Redis],
         texts: List[str],
-        images: List[str],
+        images: List[str] = None,
         embedding: Embeddings = BridgeTowerEmbedding,
         metadatas: Optional[List[dict]] = None,
         index_name: Optional[str] = None,
@@ -55,7 +56,8 @@ class MultimodalRedis(Redis):
         """
         Args:
             texts (List[str]): List of texts to add to the vectorstore.
-            images (List[str]): List of path-to-images to add to the vectorstore.
+            images (List[str]): Optional list of path-to-images to add to the vectorstore. If provided, the length of
+                the list of images must match the length of the list of text strings.
             embedding (Embeddings): Embeddings to use for the vectorstore.
             metadatas (Optional[List[dict]], optional): Optional list of metadata
                 dicts to add to the vectorstore. Defaults to None.
@@ -74,8 +76,8 @@ class MultimodalRedis(Redis):
             ValueError: If the number of texts does not equal the number of images.
             ValueError: If the number of metadatas does not match the number of texts.
         """
-        # the length of texts must be equal to the length of images
-        if len(texts) != len(images):
+        # If images are provided, the length of texts must be equal to the length of images
+        if images and len(texts) != len(images):
             raise ValueError(f"the len of captions {len(texts)} does not equal the len of images {len(images)}")
 
         redis_url = get_from_dict_or_env(kwargs, "redis_url", "REDIS_URL")
@@ -117,7 +119,8 @@ class MultimodalRedis(Redis):
             **kwargs,
         )
         # Add data to Redis
-        keys = instance.add_text_image_pairs(texts, images, metadatas, keys=keys)
+        keys = instance.add_text_image_pairs(texts, images, metadatas, keys=keys) if images else \
+            instance.add_text(texts, metadatas, keys=keys)
         return instance, keys
 
     def add_text_image_pairs(
@@ -187,6 +190,66 @@ class MultimodalRedis(Redis):
         # Cleanup final batch
         pipeline.execute()
         return ids
+    
+    def add_text(
+        self,
+        texts: Iterable[str],
+        metadatas: Optional[List[dict]] = None,
+        embeddings: Optional[List[List[float]]] = None,
+        clean_metadata: bool = True,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Add more embeddings of text to the vectorstore.
+
+        Args:
+            texts (Iterable[str]): Iterable of strings/text to add to the vectorstore.
+            metadatas (Optional[List[dict]], optional): Optional list of metadatas.
+                Defaults to None.
+            embeddings (Optional[List[List[float]]], optional): Optional pre-generated
+                embeddings. Defaults to None.
+            keys (List[str]) or ids (List[str]): Identifiers of entries.
+                Defaults to None.
+        Returns:
+            List[str]: List of ids added to the vectorstore
+        """
+        ids = []
+        # Get keys or ids from kwargs
+        # Other vectorstores use ids
+        keys_or_ids = kwargs.get("keys", kwargs.get("ids"))
+
+        # type check for metadata
+        if metadatas:
+            if isinstance(metadatas, list) and len(metadatas) != len(texts):  # type: ignore  # noqa: E501
+                raise ValueError("Number of metadatas must match number of texts")
+            if not (isinstance(metadatas, list) and isinstance(metadatas[0], dict)):
+                raise ValueError("Metadatas must be a list of dicts")
+
+        if not embeddings:
+            embeddings = self._embeddings.embed_documents(list(texts))
+        self._create_index_if_not_exist(dim=len(embeddings[0]))
+
+        # Write data to redis
+        pipeline = self.client.pipeline(transaction=False)
+        for i, text in enumerate(texts):
+            # Use provided values by default or fallback
+            key = keys_or_ids[i] if keys_or_ids else str(uuid.uuid4().hex)
+            if not key.startswith(self.key_prefix + ":"):
+                key = self.key_prefix + ":" + key
+            metadata = metadatas[i] if metadatas else {}
+            metadata = _prepare_metadata(metadata) if clean_metadata else metadata
+            pipeline.hset(
+                key,
+                mapping={
+                    self._schema.content_key: text,
+                    self._schema.content_vector_key: _array_to_buffer(embeddings[i], self._schema.vector_dtype),
+                    **metadata,
+                },
+            )
+            ids.append(key)
+
+        # Cleanup final batch
+        pipeline.execute()
+        return ids
 
 
 def prepare_data_and_metadata_from_annotation(
@@ -211,11 +274,14 @@ def prepare_data_and_metadata_from_annotation(
         video_id = frame["video_id"]
         b64_img_str = frame["b64_img_str"]
         time_of_frame = frame["time"]
-        embedding_type = "pair"
+        embedding_type = "pair" if b64_img_str else "text"
         source_video = frame["video_name"]
 
         text_list.append(caption_for_ingesting)
-        image_list.append(path_to_frame)
+
+        if b64_img_str:
+            image_list.append(path_to_frame)
+
         metadatas.append(
             {
                 "content": caption_for_ingesting,
@@ -269,44 +335,51 @@ def drop_index(index_name, redis_url=REDIS_URL):
     name="opea_service@prepare_videodoc_redis", endpoint="/v1/generate_transcripts", host="0.0.0.0", port=6007
 )
 async def ingest_videos_generate_transcripts(files: List[UploadFile] = File(None)):
-    """Upload videos with speech, generate transcripts using whisper and ingest into redis."""
+    """Upload videos or audio files with speech, generate transcripts using whisper and ingest into redis."""
 
     if files:
-        video_files = []
-        uploaded_videos_saved_videos_map = {}
+        files_to_ingest = []
+        uploaded_files_map = {}
         for file in files:
-            if os.path.splitext(file.filename)[1] == ".mp4":
-                video_files.append(file)
+            if os.path.splitext(file.filename)[1] in [".mp4", ".wav"]:
+                files_to_ingest.append(file)
             else:
                 raise HTTPException(
                     status_code=400, detail=f"File {file.filename} is not an mp4 file. Please upload mp4 files only."
                 )
 
-        for video_file in video_files:
+        for file_to_ingest in files_to_ingest:
             st = time.time()
-            print(f"Processing video {video_file.filename}")
+            file_extension = os.path.splitext(file_to_ingest.filename)[1]
+            is_video = file_extension == ".mp4"
+            file_type_str = "video" if is_video else "audio file"
+            print(f"Processing {file_type_str} {file_to_ingest.filename}")
 
             # Assign unique identifier to video
-            video_id = generate_id()
+            file_id = generate_id()
 
             # Create video file name by appending identifier
-            video_name = os.path.splitext(video_file.filename)[0]
-            video_file_name = f"{video_name}_{video_id}.mp4"
-            video_dir_name = os.path.splitext(video_file_name)[0]
+            base_file_name = os.path.splitext(file_to_ingest.filename)[0]
+            file_name_with_id = f"{base_file_name}_{file_id}{file_extension}"
+            dir_name = os.path.splitext(file_name_with_id)[0]
 
-            # Save video file in upload_directory
-            with open(os.path.join(upload_folder, video_file_name), "wb") as f:
-                shutil.copyfileobj(video_file.file, f)
+            # Save file in upload_directory
+            with open(os.path.join(upload_folder, file_name_with_id), "wb") as f:
+                shutil.copyfileobj(file_to_ingest.file, f)
 
-            uploaded_videos_saved_videos_map[video_name] = video_file_name
+            uploaded_files_map[base_file_name] = file_name_with_id
 
-            # Extract temporary audio wav file from video mp4
-            audio_file = video_dir_name + ".wav"
-            print(f"Extracting {audio_file}")
-            convert_video_to_audio(
-                os.path.join(upload_folder, video_file_name), os.path.join(upload_folder, audio_file)
-            )
-            print(f"Done extracting {audio_file}")
+            if is_video:
+                # Extract temporary audio wav file from video mp4
+                audio_file = dir_name + ".wav"
+                print(f"Extracting {audio_file}")
+                convert_video_to_audio(
+                    os.path.join(upload_folder, file_name_with_id), os.path.join(upload_folder, audio_file)
+                )
+                print(f"Done extracting {audio_file}")
+            else:
+                # We already have an audio file
+                audio_file = file_name_with_id
 
             # Load whisper model
             print("Loading whisper model....")
@@ -318,41 +391,53 @@ async def ingest_videos_generate_transcripts(files: List[UploadFile] = File(None
             transcripts = extract_transcript_from_audio(whisper_model, os.path.join(upload_folder, audio_file))
 
             # Save transcript as vtt file and delete audio file
-            vtt_file = video_dir_name + ".vtt"
+            vtt_file = dir_name + ".vtt"
             write_vtt(transcripts, os.path.join(upload_folder, vtt_file))
-            delete_audio_file(os.path.join(upload_folder, audio_file))
+            if is_video:
+                delete_audio_file(os.path.join(upload_folder, audio_file))
             print("Done extracting transcript.")
 
-            # Store frames and caption annotations in a new directory
-            print("Extracting frames and generating annotation")
-            extract_frames_and_annotations_from_transcripts(
-                video_id,
-                os.path.join(upload_folder, video_file_name),
-                os.path.join(upload_folder, vtt_file),
-                os.path.join(upload_folder, video_dir_name),
-            )
+            if is_video:
+                # Store frames and caption annotations in a new directory
+                print("Extracting frames and generating annotation")
+                extract_frames_and_annotations_from_transcripts(
+                    file_id,
+                    os.path.join(upload_folder, file_name_with_id),
+                    os.path.join(upload_folder, vtt_file),
+                    os.path.join(upload_folder, dir_name),
+                )
+            else:
+                # Generate annotations based on the transcript
+                print("Generating annotations for the transcription")
+                generate_annotations_from_transcript(
+                    file_id,
+                    os.path.join(upload_folder, file_name_with_id),
+                    os.path.join(upload_folder, vtt_file),
+                    os.path.join(upload_folder, dir_name),
+                )
+   
             print("Done extracting frames and generating annotation")
             # Delete temporary vtt file
             os.remove(os.path.join(upload_folder, vtt_file))
 
             # Ingest multimodal data into redis
             print("Ingesting data to redis vector store")
-            ingest_multimodal(video_name, os.path.join(upload_folder, video_dir_name), embeddings)
+            ingest_multimodal(base_file_name, os.path.join(upload_folder, dir_name), embeddings)
 
             # Delete temporary video directory containing frames and annotations
-            shutil.rmtree(os.path.join(upload_folder, video_dir_name))
+            shutil.rmtree(os.path.join(upload_folder, dir_name))
 
-            print(f"Processed video {video_file.filename}")
+            print(f"Processed file {file_to_ingest.filename}")
             end = time.time()
             print(str(end - st))
 
         return {
             "status": 200,
             "message": "Data preparation succeeded",
-            "file_id_maps": uploaded_videos_saved_videos_map,
+            "file_id_maps": uploaded_files_map,
         }
 
-    raise HTTPException(status_code=400, detail="Must provide at least one video (.mp4) file.")
+    raise HTTPException(status_code=400, detail="Must provide at least one video (.mp4) or audio (.wav) file.")
 
 
 @register_microservice(

--- a/comps/dataprep/multimodal/redis/langchain/prepare_videodoc_redis.py
+++ b/comps/dataprep/multimodal/redis/langchain/prepare_videodoc_redis.py
@@ -334,7 +334,7 @@ def drop_index(index_name, redis_url=REDIS_URL):
 @register_microservice(
     name="opea_service@prepare_videodoc_redis", endpoint="/v1/generate_transcripts", host="0.0.0.0", port=6007
 )
-async def ingest_videos_generate_transcripts(files: List[UploadFile] = File(None)):
+async def ingest_generate_transcripts(files: List[UploadFile] = File(None)):
     """Upload videos or audio files with speech, generate transcripts using whisper and ingest into redis."""
 
     if files:

--- a/comps/embeddings/multimodal/bridgetower/bridgetower_embedding.py
+++ b/comps/embeddings/multimodal/bridgetower/bridgetower_embedding.py
@@ -56,7 +56,8 @@ class BridgeTowerEmbedding(BaseModel, Embeddings):
         Returns:
             List of embeddings, one for each text.
         """
-        encodings = self.PROCESSOR.tokenizer(texts, return_tensors="pt").to(self.device)
+        encodings = self.PROCESSOR.tokenizer(
+            texts, return_tensors="pt", max_length=200, padding="max_length", truncation=True).to(self.device)
         with torch.no_grad():
             outputs = self.TEXT_MODEL(**encodings)
         embeddings = outputs.cpu().numpy().tolist()

--- a/comps/lvms/llava/README.md
+++ b/comps/lvms/llava/README.md
@@ -103,8 +103,11 @@ docker run -p 9399:9399 --ipc=host -e http_proxy=$http_proxy -e https_proxy=$htt
 ```bash
 # Use curl/python
 
-# curl
+# curl with an image and a prompt
 http_proxy="" curl http://localhost:9399/v1/lvm -XPOST -d '{"image": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mP8/5+hnoEIwDiqkL4KAcT9GO0U4BxoAAAAAElFTkSuQmCC", "prompt":"What is this?"}' -H 'Content-Type: application/json'
+
+# curl with a prompt only (no image)
+http_proxy="" curl http://localhost:9399/v1/lvm -XPOST -d '{"image": "", "prompt":"What is deep learning?"}' -H 'Content-Type: application/json'
 
 # python
 python check_lvm.py

--- a/comps/lvms/llava/dependency/llava_server.py
+++ b/comps/lvms/llava/dependency/llava_server.py
@@ -14,6 +14,7 @@ import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, Response
 from transformers import pipeline
+from transformers.image_utils import load_image
 
 model_name_or_path = None
 model_dtype = None
@@ -23,6 +24,71 @@ generator = None
 
 
 app = FastAPI()
+
+def pipeline_preprocess(self, image, prompt=None, timeout=None):
+    """
+    This replaces the preprocess function used by the image-to-text pipeline
+    (https://github.com/huggingface/transformers/blob/main/src/transformers/pipelines/image_to_text.py).
+    The original transformers image-to-text pipeline preprocess function requires that an image is passed in, and will
+    fail if the image parameter is null/empty. In order to support multimodal use cases with the same pipeline, this
+    preprocess function handles the case where there is no image with the prompt.
+    """
+
+    if image:
+        image = load_image(image, timeout=timeout)
+
+    if prompt is not None:
+        if not isinstance(prompt, str):
+            raise ValueError(
+                f"Received an invalid text input, got - {type(prompt)} - but expected a single string. "
+                "Note also that one single text can be provided for conditional image to text generation."
+            )
+
+        model_type = self.model.config.model_type
+
+        if model_type == "git":
+            if image:
+                model_inputs = self.image_processor(images=image, return_tensors=self.framework)
+                if self.framework == "pt":
+                    model_inputs = model_inputs.to(self.torch_dtype)
+            else:
+                model_inputs = {}
+            input_ids = self.tokenizer(text=prompt, add_special_tokens=False).input_ids
+            input_ids = [self.tokenizer.cls_token_id] + input_ids
+            input_ids = torch.tensor(input_ids).unsqueeze(0)
+            model_inputs.update({"input_ids": input_ids})
+        elif model_type == "pix2struct":
+            model_inputs = self.image_processor(images=image, header_text=prompt, return_tensors=self.framework)
+            if self.framework == "pt":
+                model_inputs = model_inputs.to(self.torch_dtype)
+
+        elif model_type != "vision-encoder-decoder":
+            if image:
+                # vision-encoder-decoder does not support conditional generation
+                model_inputs = self.image_processor(images=image, return_tensors=self.framework)
+
+                if self.framework == "pt":
+                    model_inputs = model_inputs.to(self.torch_dtype)
+            else:
+                model_inputs = {}
+
+            text_inputs = self.tokenizer(prompt, return_tensors=self.framework)
+            model_inputs.update(text_inputs)
+
+        else:
+            raise ValueError(f"Model type {model_type} does not support conditional text generation")
+
+    elif image:
+        model_inputs = self.image_processor(images=image, return_tensors=self.framework)
+        if self.framework == "pt":
+            model_inputs = model_inputs.to(self.torch_dtype)
+    else:
+        raise ValueError("Both image and prompt cannot be empty.")
+
+    if self.model.config.model_type == "git" and prompt is None:
+        model_inputs["input_ids"] = None
+
+    return model_inputs
 
 
 def process_image(image, max_len=1344, min_len=672):
@@ -54,12 +120,16 @@ async def generate(request: Request) -> Response:  # FIXME batch_size=1 for now,
     img_b64_str = request_dict.pop("img_b64_str")
     max_new_tokens = request_dict.pop("max_new_tokens", 100)
 
-    # format the prompt
-    prompt = f"<image>\nUSER: {prompt}\nASSISTANT:"
-
-    # Decode and Resize the image
-    image = PIL.Image.open(BytesIO(base64.b64decode(img_b64_str)))
-    image = process_image(image)
+    if img_b64_str:
+        # Decode and Resize the image
+        image = PIL.Image.open(BytesIO(base64.b64decode(img_b64_str)))
+        image = process_image(image)
+        # format the prompt with an image
+        prompt = f"<image>\nUSER: {prompt}\nASSISTANT:"
+    else:
+        image = None
+        # format the prompt with text only
+        prompt = f"USER: {prompt}\nASSISTANT:"
 
     if args.device == "hpu":
         generate_kwargs = {
@@ -74,11 +144,17 @@ async def generate(request: Request) -> Response:  # FIXME batch_size=1 for now,
         }
 
     start = time.time()
+
+    # Override the pipeline preprocessing
+    generator.preprocess = pipeline_preprocess.__get__(generator, type(generator))
+
     result = generator(image, prompt=prompt, batch_size=1, generate_kwargs=generate_kwargs)
     end = time.time()
     result = result[0]["generated_text"].split("ASSISTANT: ")[-1]
     print(f"LLaVA result = {result}, time = {(end-start) * 1000 }ms")
-    image.close()
+    if image:
+        image.close()
+
     ret = {"text": result}
     return JSONResponse(ret)
 

--- a/comps/lvms/llava/lvm.py
+++ b/comps/lvms/llava/lvm.py
@@ -52,11 +52,12 @@ async def lvm(request: Union[LVMDoc, LVMSearchedMultimodalDoc]) -> Union[TextDoc
             raise HTTPException(status_code=500, detail="There is no video segments retrieved given the query!")
 
         img_b64_str = retrieved_metadatas[0]["b64_img_str"]
+        has_image = img_b64_str != ""
         initial_query = request.initial_query
         context = retrieved_metadatas[0]["transcript_for_inference"]
         prompt = initial_query
         if request.chat_template is None:
-            prompt = ChatTemplate.generate_multimodal_rag_on_videos_prompt(initial_query, context)
+            prompt = ChatTemplate.generate_multimodal_rag_on_videos_prompt(initial_query, context, has_image)
         else:
             prompt_template = PromptTemplate.from_template(request.chat_template)
             input_variables = prompt_template.input_variables

--- a/comps/lvms/llava/template.py
+++ b/comps/lvms/llava/template.py
@@ -5,6 +5,11 @@
 class ChatTemplate:
 
     @staticmethod
-    def generate_multimodal_rag_on_videos_prompt(question: str, context: str):
-        template = """The transcript associated with the image is '{context}'. {question}"""
+    def generate_multimodal_rag_on_videos_prompt(question: str, context: str, has_image: bool = False):
+
+        if has_image:
+            template = """The transcript associated with the image is '{context}'. {question}"""
+        else:
+            template = """Refer to the following results obtained from the local knowledge base: '{context}'. {question}"""
+
         return template.format(context=context, question=question)

--- a/tests/dataprep/test_dataprep_multimodal_redis_langchain.sh
+++ b/tests/dataprep/test_dataprep_multimodal_redis_langchain.sh
@@ -14,6 +14,8 @@ INDEX_NAME="dataprep"
 video_name="WeAreGoingOnBullrun"
 transcript_fn="${video_name}.vtt"
 video_fn="${video_name}.mp4"
+audio_name="AudioSample"
+audio_fn="${audio_name}.wav"
 image_name="apple"
 image_fn="${image_name}.png"
 
@@ -123,6 +125,9 @@ tire.""" > ${transcript_fn}
     echo "Downloading Video"
     wget http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/WeAreGoingOnBullrun.mp4 -O ${video_fn}
 
+    echo "Downloading Audio"
+    wget https://github.com/intel/intel-extension-for-transformers/raw/main/intel_extension_for_transformers/neural_chat/assets/audio/sample.wav -O ${audio_fn}
+
 }
 
 function validate_microservice() {
@@ -131,7 +136,7 @@ function validate_microservice() {
     # test v1/generate_transcripts upload file
     echo "Testing generate_transcripts API"
     URL="http://${ip_address}:$dataprep_service_port/v1/generate_transcripts"
-    HTTP_RESPONSE=$(curl --silent --write-out "HTTPSTATUS:%{http_code}" -X POST -F "files=@./$video_fn" -H 'Content-Type: multipart/form-data' "$URL")
+    HTTP_RESPONSE=$(curl --silent --write-out "HTTPSTATUS:%{http_code}" -X POST -F "files=@./$video_fn" -F "files=@./$audio_fn"  -H 'Content-Type: multipart/form-data' "$URL")
     HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
     RESPONSE_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
     SERVICE_NAME="dataprep - upload - file"
@@ -238,7 +243,7 @@ function validate_microservice() {
     else
         echo "[ $SERVICE_NAME ] HTTP status is 200. Checking content..."
     fi
-    if [[ "$RESPONSE_BODY" != *${image_name}* || "$RESPONSE_BODY" != *${video_name}* ]]; then
+    if [[ "$RESPONSE_BODY" != *${image_name}* || "$RESPONSE_BODY" != *${video_name}* || "$RESPONSE_BODY" != *${audio_name}* ]]; then
         echo "[ $SERVICE_NAME ] Content does not match the expected result: $RESPONSE_BODY"
         docker logs test-comps-dataprep-multimodal-redis >> ${LOG_PATH}/dataprep_file.log
         exit 1

--- a/tests/lvms/test_lvms_llava.sh
+++ b/tests/lvms/test_lvms_llava.sh
@@ -68,6 +68,17 @@ function validate_microservice() {
         exit 1
     fi
 
+    # Test the LVM with text only (no image)
+    result=$(http_proxy="" curl http://localhost:$lvm_port/v1/lvm -XPOST -d '{"image": "", "prompt":"What is deep learning?"}' -H 'Content-Type: application/json')
+    if [[ $result == *"Deep learning is"* ]]; then
+        echo "Result correct."
+    else
+        echo "Result wrong."
+        docker logs test-comps-lvm-llava >> ${LOG_PATH}/llava-dependency.log
+        docker logs test-comps-lvm-llava-svc >> ${LOG_PATH}/llava-server.log
+        exit 1
+    fi
+
 }
 
 function stop_docker() {


### PR DESCRIPTION
## Description

This PR adds support for passing audio files to the data prep stage for MultimodalQnA. Base64 encoded audio files can e passed to the `generate_transcript` data prep endpoint, and they will be transcribed the same way it's already done for the audio from a video file. The LVM microservice also had to be updated, in order to handle prompts with text only (no image). We will have text only from MMQnA when a user query is found to be related to text in the vector store that originally came from an audio file. Previously, when MMQnA just supported video, the text in the vector store always had an associated image/frame, but that is no longer the case when audio files are used. The LVM microservice is using the transformers image-to-text pipeline under-the-hood, which has image as a required parameter. In order to get around this, I modified the preprocessing function that will be used with the pipeline to make the image optional. When the LVM is prompted with text only, it basically acts like a LLM.

## Issues

https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds new functionality)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

I tested the full MMQnA flow by uploading a .wav file using a curl command, and then I used the UI to ask a question related to the .wav file and verified that I get back a reasonable response.

I also added tests to GenAIComps for data prep (to verify generate_transcript for an audio file) and the LVM (to verify prompting without an image).
