### PR TITLE
Image+Text Ingestion

### DIFF
--- a/comps/dataprep/multimodal/redis/langchain/README.md
+++ b/comps/dataprep/multimodal/redis/langchain/README.md
@@ -114,7 +114,7 @@ Once this dataprep microservice is started, user can use the below commands to i
 
 This microservice has provided 3 different ways for users to ingest files into Redis vector store corresponding to the 3 use cases.
 
-### 4.1 Consume _videos_with_transcripts_ API
+### 4.1 Consume _ingest_with_text_ API
 
 **Use case:** This API is used when a transcript file (under `.vtt` format) is available for each video.
 
@@ -130,7 +130,7 @@ curl -X POST \
     -H "Content-Type: multipart/form-data" \
     -F "files=@./video1.mp4" \
     -F "files=@./video1.vtt" \
-    http://localhost:6007/v1/videos_with_transcripts
+    http://localhost:6007/v1/ingest_with_text
 ```
 
 #### Multiple video-transcript pair upload
@@ -142,7 +142,7 @@ curl -X POST \
     -F "files=@./video1.vtt" \
     -F "files=@./video2.mp4" \
     -F "files=@./video2.vtt" \
-    http://localhost:6007/v1/videos_with_transcripts
+    http://localhost:6007/v1/ingest_with_text
 ```
 
 ### 4.2 Consume _generate_transcripts_ API

--- a/comps/dataprep/multimodal/redis/langchain/README.md
+++ b/comps/dataprep/multimodal/redis/langchain/README.md
@@ -143,7 +143,7 @@ curl -X POST \
     http://localhost:6007/v1/ingest_with_text
 ```
 
-#### Multiple video-transcript pair upload
+#### Multiple file pair upload
 
 ```bash
 curl -X POST \
@@ -152,6 +152,10 @@ curl -X POST \
     -F "files=@./video1.vtt" \
     -F "files=@./video2.mp4" \
     -F "files=@./video2.vtt" \
+    -F "files=@./image1.png" \
+    -F "files=@./image1.txt" \
+    -F "files=@./image2.jpg" \
+    -F "files=@./image2.txt" \
     http://localhost:6007/v1/ingest_with_text
 ```
 

--- a/comps/dataprep/multimodal/redis/langchain/README.md
+++ b/comps/dataprep/multimodal/redis/langchain/README.md
@@ -2,7 +2,7 @@
 
 This `dataprep` microservice accepts the following from the user and ingests them into a Redis vectorstore:
 * Videos (mp4 files) and their transcripts (optional)
-* Images (gif, jpg, jpeg, and png files)
+* Images (gif, jpg, jpeg, and png files) and their captions (optional)
 * Audio (wav files)
 
 ## 🚀1. Start Microservice with Python（Option 1）
@@ -116,12 +116,12 @@ This microservice has provided 3 different ways for users to ingest files into R
 
 ### 4.1 Consume _ingest_with_text_ API
 
-**Use case:** This API is used when a transcript file (under `.vtt` format) is available for each video.
+**Use case:** This API is used when videos are accompanied by transcript files (`.vtt` format) or images are accompanied by text caption files (`.txt` format).
 
 **Important notes:**
 
 - Make sure the file paths after `files=@` are correct.
-- Every transcript file's name must be identical with its corresponding video file's name (except their extension .vtt and .mp4). For example, `video1.mp4` and `video1.vtt`. Otherwise, if `video1.vtt` is not included correctly in this API call, this microservice will return error `No captions file video1.vtt found for video1.mp4`.
+- Every transcript or caption file's name must be identical to its corresponding video or image file's name (except their extension - .vtt goes with .mp4 and .txt goes with .jpg, .jpeg, .png, or .gif). For example, `video1.mp4` and `video1.vtt`. Otherwise, if `video1.vtt` is not included correctly in the API call, the microservice will return an error `No captions file video1.vtt found for video1.mp4`.
 
 #### Single video-transcript pair upload
 
@@ -130,6 +130,16 @@ curl -X POST \
     -H "Content-Type: multipart/form-data" \
     -F "files=@./video1.mp4" \
     -F "files=@./video1.vtt" \
+    http://localhost:6007/v1/ingest_with_text
+```
+
+#### Single image-caption pair upload
+
+```bash
+curl -X POST \
+    -H "Content-Type: multipart/form-data" \
+    -F "files=@./image.jpg" \
+    -F "files=@./image.txt" \
     http://localhost:6007/v1/ingest_with_text
 ```
 

--- a/comps/dataprep/multimodal/redis/langchain/multimodal_utils.py
+++ b/comps/dataprep/multimodal/redis/langchain/multimodal_utils.py
@@ -166,7 +166,8 @@ def generate_annotations_from_transcript(file_id: str, file_path: str, vtt_path:
 
 
 def extract_frames_and_annotations_from_transcripts(video_id: str, video_path: str, vtt_path: str, output_dir: str):
-    """Extract frames (.png) and annotations (.json) from video file (.mp4) and captions file (.vtt)"""
+    """Extract frames (.png) and annotations (.json) from media-text file pairs. File pairs can be a video
+    file (.mp4) and transcript file (.vtt) or an image file (.png, .jpg, .jpeg, .gif) and caption file (.txt)"""
     # Set up location to store frames and annotations
     os.makedirs(output_dir, exist_ok=True)
     os.makedirs(os.path.join(output_dir, "frames"), exist_ok=True)
@@ -180,7 +181,7 @@ def extract_frames_and_annotations_from_transcripts(video_id: str, video_path: s
         captions = webvtt.read(vtt_path)
     else:
         with open(vtt_path, 'r') as f:
-            captions = [line for line in f]
+            captions = f.read()
 
     annotations = []
     for idx, caption in enumerate(captions):
@@ -196,7 +197,7 @@ def extract_frames_and_annotations_from_transcripts(video_id: str, video_path: s
         else:
             frame_no = 0
             mid_time_ms = 0
-            text = captions[0].replace("\n", " ")
+            text = captions.replace("\n", " ")
 
         vidcap.set(cv2.CAP_PROP_POS_MSEC, mid_time_ms)
         success, frame = vidcap.read()

--- a/comps/dataprep/multimodal/redis/langchain/multimodal_utils.py
+++ b/comps/dataprep/multimodal/redis/langchain/multimodal_utils.py
@@ -176,18 +176,28 @@ def extract_frames_and_annotations_from_transcripts(video_id: str, video_path: s
     fps = vidcap.get(cv2.CAP_PROP_FPS)
 
     # read captions file
-    captions = webvtt.read(vtt_path)
+    if os.path.splitext(vtt_path)[-1] == ".vtt":
+        captions = webvtt.read(vtt_path)
+    else:
+        with open(vtt_path, 'r') as f:
+            captions = [line for line in f]
 
     annotations = []
     for idx, caption in enumerate(captions):
-        start_time = str2time(caption.start)
-        end_time = str2time(caption.end)
+        if os.path.splitext(vtt_path)[-1] == ".vtt":
+            start_time = str2time(caption.start)
+            end_time = str2time(caption.end)
 
-        mid_time = (end_time + start_time) / 2
-        text = caption.text.replace("\n", " ")
+            mid_time = (end_time + start_time) / 2
+            text = caption.text.replace("\n", " ")
 
-        frame_no = time_to_frame(mid_time, fps)
-        mid_time_ms = mid_time * 1000
+            frame_no = time_to_frame(mid_time, fps)
+            mid_time_ms = mid_time * 1000
+        else:
+            frame_no = 0
+            mid_time_ms = 0
+            text = captions[0].replace("\n", " ")
+
         vidcap.set(cv2.CAP_PROP_POS_MSEC, mid_time_ms)
         success, frame = vidcap.read()
 

--- a/comps/dataprep/multimodal/redis/langchain/prepare_videodoc_redis.py
+++ b/comps/dataprep/multimodal/redis/langchain/prepare_videodoc_redis.py
@@ -500,11 +500,11 @@ async def ingest_videos_generate_caption(files: List[UploadFile] = File(None)):
 
 @register_microservice(
     name="opea_service@prepare_videodoc_redis",
-    endpoint="/v1/videos_with_transcripts",
+    endpoint="/v1/ingest_with_text",
     host="0.0.0.0",
     port=6007,
 )
-async def ingest_videos_with_transcripts(files: List[UploadFile] = File(None)):
+async def ingest_with_text(files: List[UploadFile] = File(None)):
 
     if files:
         video_files, video_file_names = [], []

--- a/tests/dataprep/test_dataprep_multimodal_redis_langchain.sh
+++ b/tests/dataprep/test_dataprep_multimodal_redis_langchain.sh
@@ -156,9 +156,9 @@ function validate_microservice() {
         echo "[ $SERVICE_NAME ] Content is as expected."
     fi
 
-    # test v1/videos_with_transcripts upload file
-    echo "Testing videos_with_transcripts API"
-    URL="http://${ip_address}:$dataprep_service_port/v1/videos_with_transcripts"
+    # test v1/ingest_with_text upload file
+    echo "Testing ingest_with_text API"
+    URL="http://${ip_address}:$dataprep_service_port/v1/ingest_with_text"
 
     HTTP_RESPONSE=$(curl --silent --write-out "HTTPSTATUS:%{http_code}" -X POST -F "files=@./$video_fn" -F "files=@./$transcript_fn" -H 'Content-Type: multipart/form-data' "$URL")
     HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')


### PR DESCRIPTION
## Description

This PR changes the endpoint for video+vtt ingestion from `/videos_with_transcripts` to `/ingest_with_text` and adds support for image+txt files. As with videos, the endpoint can take one or multiple image files and the text files have to have the same base name as the corresponding image file, so the service knows which caption goes with which image.

## Issues

[MultimodalQnA Enhancements RFC](https://github.com/opea-project/docs/pull/208)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change* (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

* I'm making the corresponding change in GenAIExamples' MultimodalQnA, but any other clients using the `/videos_with_transcripts` endpoint would be affected.

## Dependencies

No new dependencies

## Tests

Updated and manually ran parts of `test_dataprep_multimodal_redis_langchain.sh`
