### PR TITLE
LVM TGI Gaudi update for prompts without images

### DIFF
--- a/comps/lvms/tgi-llava/lvm_tgi.py
+++ b/comps/lvms/tgi-llava/lvm_tgi.py
@@ -54,11 +54,12 @@ async def lvm(request: Union[LVMDoc, LVMSearchedMultimodalDoc]) -> Union[TextDoc
             # due to llava-tgi-gaudi should receive image as input; Otherwise, the generated text is bad.
             raise HTTPException(status_code=500, detail="There is no video segments retrieved given the query!")
         img_b64_str = retrieved_metadatas[0]["b64_img_str"]
+        has_image = img_b64_str != ""
         initial_query = request.initial_query
         context = retrieved_metadatas[0]["transcript_for_inference"]
         prompt = initial_query
         if request.chat_template is None:
-            prompt = ChatTemplate.generate_multimodal_rag_on_videos_prompt(initial_query, context)
+            prompt = ChatTemplate.generate_multimodal_rag_on_videos_prompt(initial_query, context, has_image)
         else:
             prompt_template = PromptTemplate.from_template(request.chat_template)
             input_variables = prompt_template.input_variables
@@ -87,7 +88,14 @@ async def lvm(request: Union[LVMDoc, LVMSearchedMultimodalDoc]) -> Union[TextDoc
         top_k = request.top_k
         top_p = request.top_p
 
-    image = f"data:image/png;base64,{img_b64_str}"
+    if img_b64_str:
+        image = f"data:image/png;base64,{img_b64_str}"
+    else:
+        # Work around an issue where LLaVA-NeXT is not providing good responses when prompted without an image.
+        # Provide an image and then instruct the model to ignore the image.
+        image = "https://raw.githubusercontent.com/opea-project/GenAIExamples/refs/tags/v1.0/AudioQnA/ui/svelte/src/lib/assets/icons/png/audio1.png"
+        prompt = f"Please disregard the image and then answer the question. {prompt}"
+
     image_prompt = f"![]({image})\n{prompt}\nASSISTANT:"
 
     if streaming:

--- a/comps/lvms/tgi-llava/lvm_tgi.py
+++ b/comps/lvms/tgi-llava/lvm_tgi.py
@@ -94,7 +94,7 @@ async def lvm(request: Union[LVMDoc, LVMSearchedMultimodalDoc]) -> Union[TextDoc
         # Work around an issue where LLaVA-NeXT is not providing good responses when prompted without an image.
         # Provide an image and then instruct the model to ignore the image.
         image = "https://raw.githubusercontent.com/opea-project/GenAIExamples/refs/tags/v1.0/AudioQnA/ui/svelte/src/lib/assets/icons/png/audio1.png"
-        prompt = f"Please disregard the image and then answer the question. {prompt}"
+        prompt = f"Please disregard the image and answer the question. {prompt}"
 
     image_prompt = f"![]({image})\n{prompt}\nASSISTANT:"
 

--- a/comps/lvms/tgi-llava/template.py
+++ b/comps/lvms/tgi-llava/template.py
@@ -5,6 +5,11 @@
 class ChatTemplate:
 
     @staticmethod
-    def generate_multimodal_rag_on_videos_prompt(question: str, context: str):
-        template = """The transcript associated with the image is '{context}'. {question}"""
+    def generate_multimodal_rag_on_videos_prompt(question: str, context: str, has_image: bool = False):
+
+        if has_image:
+            template = """The transcript associated with the image is '{context}'. {question}"""
+        else:
+            template = """Refer to the following results obtained from the local knowledge base: '{context}'. {question}"""
+
         return template.format(context=context, question=question)

--- a/tests/lvms/test_lvms_tgi-llava_on_intel_hpu.sh
+++ b/tests/lvms/test_lvms_tgi-llava_on_intel_hpu.sh
@@ -34,12 +34,24 @@ function validate_microservice() {
     lvm_port=5050
     result=$(http_proxy="" curl http://localhost:$lvm_port/v1/lvm -XPOST -d '{"image": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mP8/5+hnoEIwDiqkL4KAcT9GO0U4BxoAAAAAElFTkSuQmCC", "prompt":"What is this?"}' -H 'Content-Type: application/json')
     if [[ $result == *"yellow"* ]]; then
-        echo "Result correct."
+        echo "LVM prompt with an image - Result correct."
     else
-        echo "Result wrong."
+        echo "LVM prompt with an image - Result wrong."
         docker logs test-comps-lvm-tgi-llava >> ${LOG_PATH}/llava-dependency.log
         docker logs test-comps-lvm-tgi >> ${LOG_PATH}/llava-server.log
         exit 1
+    fi
+
+    result=$(http_proxy="" curl http://localhost:$lvm_port/v1/lvm --silent --write-out "HTTPSTATUS:%{http_code}" -XPOST -d '{"image": "", "prompt":"What is deep learning?"}' -H 'Content-Type: application/json')
+    http_status=$(echo $result | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+    if [ "$http_status" -ne "200" ]; then
+
+        echo "LVM prompt without image - HTTP status is not 200. Received status was $http_status"
+        docker logs test-comps-lvm-tgi-llava >> ${LOG_PATH}/llava-dependency.log
+        docker logs test-comps-lvm-tgi >> ${LOG_PATH}/llava-server.log
+        exit 1
+    else
+        echo "LVM prompt without image - HTTP status (successful)"
     fi
 
 }


### PR DESCRIPTION
## Description

TGI Gaudi is having an issue where it does not give a good response for prompts without an image. I investigated it down to prompting the model using transformers only and am still seeing the issue. Providing an image along with prompt and asking the LVM to ignore the image seems to be the best way to be able to use TGI and workaround the issue. Note that Llava 1.5 does not seem to have this issue, however TGI Gaudi does not support Llava 1.5 (only Llava 1.6).

Also, I tried giving it more of a dummy image (like a single pixel/solid color) and that did not give good results, even when asking the LVM to ignore the image, so I'm giving it a small image from GenAIExamples, which seems to yield reasonable results.

## Issues

https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

N/A

## Tests

TBD
