### PR TITLE
Test fix

### DIFF
--- a/tests/dataprep/test_dataprep_multimodal_redis_langchain.sh
+++ b/tests/dataprep/test_dataprep_multimodal_redis_langchain.sh
@@ -248,7 +248,7 @@ function validate_microservice() {
     else
         echo "[ $SERVICE_NAME ] HTTP status is 400. Checking content..."
     fi
-    if [[ "$RESPONSE_BODY" != *"No caption file found for $image_fn"* ]]; then
+    if [[ "$RESPONSE_BODY" != *"No caption file found for $image_name"* ]]; then
         echo "[ $SERVICE_NAME ] Content does not match the expected result: $RESPONSE_BODY"
         docker logs test-comps-dataprep-multimodal-redis >> ${LOG_PATH}/dataprep_upload_file.log
         exit 1


### PR DESCRIPTION
## Description

Fix the response message to only include the file name, not the full path. The test is failing when trying to match on the response:
```
+ [[ {"detail":"No caption file found for apple.png"} != *\N\o\ \c\a\p\t\i\o\n\ \f\i\l\e\ \f\o\u\n\d\ \f\o\r\ \/\t\m\p\/\t\m\p\.\N\5\F\Y\3\8\J\b\v\k\/\a\p\p\l\e\.\p\n\g* ]]
+ echo '[ dataprep - upload - file ] Content does not match the expected result: {"detail":"No caption file found for apple.png"}'
```

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

-  [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
