### PR TITLE
Fixed role bug where enumeration was wrong

### DIFF
--- a/comps/cores/mega/gateway.py
+++ b/comps/cores/mega/gateway.py
@@ -903,7 +903,7 @@ class MultimodalQnAGateway(Gateway):
 
             if system_prompt:
                 prompt = system_prompt + "\n"
-            for i, messages_dict in enumerate(messages_dicts):    
+            for i, messages_dict in enumerate(messages_dicts):
                 for (role, message) in messages_dict.items():
                     if isinstance(message, tuple):
                         text, decoded_audio_input, image_list = message

--- a/comps/cores/mega/gateway.py
+++ b/comps/cores/mega/gateway.py
@@ -903,8 +903,8 @@ class MultimodalQnAGateway(Gateway):
 
             if system_prompt:
                 prompt = system_prompt + "\n"
-            for messages_dict in messages_dicts:
-                for i, (role, message) in enumerate(messages_dict.items()):
+            for i, messages_dict in enumerate(messages_dicts):    
+                for (role, message) in messages_dict.items():
                     if isinstance(message, tuple):
                         text, decoded_audio_input, image_list = message
                         if i == 0:


### PR DESCRIPTION
## Description

in the loop on line 906, the variable `i` was in the wrong block and therefore it would never equal to a value greater than 0. This caused role to never be concatenated to the prompt string later on.

## Issues

https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A

## Tests

Verified fix with print statements