### PR TITLE
Fix port number placement

### DIFF
--- a/tests/cores/mega/test_multimodalqna_gateway.py
+++ b/tests/cores/mega/test_multimodalqna_gateway.py
@@ -9,6 +9,8 @@ from typing import Union
 import requests
 from fastapi import Request
 
+os.environ["ASR_SERVICE_PORT"] = "8086"
+
 from comps import (
     Base64ByteStrDoc,
     EmbedDoc,
@@ -106,7 +108,6 @@ class TestServiceOrchestrator(unittest.IsolatedAsyncioTestCase):
         cls.follow_up_query_service_builder = ServiceOrchestrator()
         cls.follow_up_query_service_builder.add(cls.lvm)
 
-        os.environ["ASR_SERVICE_PORT"] = "8086"
         cls.gateway = MultimodalQnAGateway(cls.service_builder, cls.follow_up_query_service_builder, port=9898)
 
     @classmethod


### PR DESCRIPTION
## Description

The test port number needs to be set as an env var before the MultimodalQnAGateway is imported.

## Issues

[RFC](https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

N/A

## Tests

The new audio query unit test passes locally now, so it should in GHA too.