### PR TITLE
MultimodalQnA PDF Ingestion

### DIFF
--- a/comps/dataprep/multimodal/redis/langchain/README.md
+++ b/comps/dataprep/multimodal/redis/langchain/README.md
@@ -5,6 +5,7 @@ This `dataprep` microservice accepts the following from the user and ingests the
 - Videos (mp4 files) and their transcripts (optional)
 - Images (gif, jpg, jpeg, and png files) and their captions (optional)
 - Audio (wav files)
+- PDFs (with text and images)
 
 ## 🚀1. Start Microservice with Python（Option 1）
 
@@ -111,18 +112,19 @@ docker container logs -f dataprep-multimodal-redis
 
 ## 🚀4. Consume Microservice
 
-Once this dataprep microservice is started, user can use the below commands to invoke the microservice to convert images and videos and their transcripts (optional) to embeddings and save to the Redis vector store.
+Once this dataprep microservice is started, user can use the below commands to invoke the microservice to convert images, videos, text, and PDF files to embeddings and save to the Redis vector store.
 
 This microservice provides 3 different ways for users to ingest files into Redis vector store corresponding to the 3 use cases.
 
 ### 4.1 Consume _ingest_with_text_ API
 
-**Use case:** This API is used when videos are accompanied by transcript files (`.vtt` format) or images are accompanied by text caption files (`.txt` format).
+**Use case:** This API is used for videos accompanied by transcript files (`.vtt` format), images accompanied by text caption files (`.txt` format), and PDF files containing a mix of text and images.
 
 **Important notes:**
 
 - Make sure the file paths after `files=@` are correct.
 - Every transcript or caption file's name must be identical to its corresponding video or image file's name (except their extension - .vtt goes with .mp4 and .txt goes with .jpg, .jpeg, .png, or .gif). For example, `video1.mp4` and `video1.vtt`. Otherwise, if `video1.vtt` is not included correctly in the API call, the microservice will return an error `No captions file video1.vtt found for video1.mp4`.
+- It is assumed that PDFs will contain at least one image. Each image in the file will be embedded along with the text that appears on the same page as the image.
 
 #### Single video-transcript pair upload
 
@@ -157,6 +159,7 @@ curl -X POST \
     -F "files=@./image1.txt" \
     -F "files=@./image2.jpg" \
     -F "files=@./image2.txt" \
+    -F "files=@./example.pdf" \
     http://localhost:6007/v1/ingest_with_text
 ```
 

--- a/comps/dataprep/multimodal/redis/langchain/prepare_videodoc_redis.py
+++ b/comps/dataprep/multimodal/redis/langchain/prepare_videodoc_redis.py
@@ -19,7 +19,6 @@ from langchain_core.embeddings import Embeddings
 from langchain_core.utils import get_from_dict_or_env
 from multimodal_utils import (
     clear_upload_folder,
-    convert_img_to_base64,
     convert_video_to_audio,
     create_upload_folder,
     delete_audio_file,
@@ -636,19 +635,21 @@ async def ingest_with_text(files: List[UploadFile] = File(None)):
                         if pix.n - pix.alpha > 3:  # if CMYK, convert to RGB first
                             pix = pymupdf.Pixmap(pymupdf.csRGB, pix)
 
-                        pix.save(img_fpath)
+                        pix.save(img_fpath)  # pixmap to png
                         pix = None
 
                         # Convert image to base64 encoded string
                         with open(img_fpath, "rb") as image2str: 
-                            encoded_string = base64.b64encode(image2str.read())
+                            encoded_string = base64.b64encode(image2str.read())  # png to bytes
+
+                        decoded_string = encoded_string.decode()  # bytes to string
 
                         # Create annotations file, reusing metadata keys from video
                         annotations.append(
                             {
                                 "video_id": file_id,
                                 "video_name": os.path.basename(os.path.join(upload_folder, media_file_name)),
-                                "b64_img_str": encoded_string.decode(),
+                                "b64_img_str": decoded_string,
                                 "caption": text,
                                 "time": 0.0,
                                 "frame_no": page_idx,

--- a/comps/dataprep/multimodal/redis/langchain/requirements.txt
+++ b/comps/dataprep/multimodal/redis/langchain/requirements.txt
@@ -11,6 +11,7 @@ opentelemetry-sdk
 Pillow
 prometheus-fastapi-instrumentator
 pydantic
+pymupdf
 python-multipart
 redis
 shortuuid

--- a/tests/dataprep/test_dataprep_multimodal_redis_langchain.sh
+++ b/tests/dataprep/test_dataprep_multimodal_redis_langchain.sh
@@ -20,6 +20,8 @@ audio_fn="${tmp_dir}/${audio_name}.wav"
 image_name="apple"
 image_fn="${tmp_dir}/${image_name}.png"
 caption_fn="${tmp_dir}/${image_name}.txt"
+pdf_name="nke-10k-2023"
+pdf_fn="${tmp_dir}/${pdf_name}.pdf"
 
 function build_docker_images() {
     cd $WORKPATH
@@ -131,6 +133,9 @@ tire.""" > ${transcript_fn}
 
     echo "Downloading Audio"
     wget https://github.com/intel/intel-extension-for-transformers/raw/main/intel_extension_for_transformers/neural_chat/assets/audio/sample.wav -O ${audio_fn}
+
+    echo "Downloading PDF"
+    wget https://raw.githubusercontent.com/opea-project/GenAIComps/main/comps/retrievers/redis/data/nke-10k-2023.pdf -O ${pdf_fn}
 
 }
 
@@ -249,6 +254,30 @@ function validate_microservice() {
         echo "[ $SERVICE_NAME ] HTTP status is 400. Checking content..."
     fi
     if [[ "$RESPONSE_BODY" != *"No caption file found for $image_name"* ]]; then
+        echo "[ $SERVICE_NAME ] Content does not match the expected result: $RESPONSE_BODY"
+        docker logs test-comps-dataprep-multimodal-redis >> ${LOG_PATH}/dataprep_upload_file.log
+        exit 1
+    else
+        echo "[ $SERVICE_NAME ] Content is as expected."
+    fi
+
+    # test v1/ingest_with_text with a PDF file
+    echo "Testing ingest_with_text API with a PDF file"
+    URL="http://${ip_address}:$dataprep_service_port/v1/ingest_with_text"
+
+    HTTP_RESPONSE=$(curl --silent --write-out "HTTPSTATUS:%{http_code}" -X POST -F "files=@$pdf_fn" -H 'Content-Type: multipart/form-data' "$URL")
+    HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+    RESPONSE_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
+    SERVICE_NAME="dataprep - upload - file"
+
+    if [ "$HTTP_STATUS" -ne "200" ]; then
+        echo "[ $SERVICE_NAME ] HTTP status is not 200. Received status was $HTTP_STATUS"
+        docker logs test-comps-dataprep-multimodal-redis >> ${LOG_PATH}/dataprep_upload_file.log
+        exit 1
+    else
+        echo "[ $SERVICE_NAME ] HTTP status is 200. Checking content..."
+    fi
+    if [[ "$RESPONSE_BODY" != *"Data preparation succeeded"* ]]; then
         echo "[ $SERVICE_NAME ] Content does not match the expected result: $RESPONSE_BODY"
         docker logs test-comps-dataprep-multimodal-redis >> ${LOG_PATH}/dataprep_upload_file.log
         exit 1

--- a/tests/dataprep/test_dataprep_multimodal_redis_langchain.sh
+++ b/tests/dataprep/test_dataprep_multimodal_redis_langchain.sh
@@ -348,7 +348,7 @@ function validate_microservice() {
     else
         echo "[ $SERVICE_NAME ] HTTP status is 200. Checking content..."
     fi
-    if [[ "$RESPONSE_BODY" != *${image_name}* || "$RESPONSE_BODY" != *${video_name}* || "$RESPONSE_BODY" != *${audio_name}* ]]; then
+    if [[ "$RESPONSE_BODY" != *${image_name}* || "$RESPONSE_BODY" != *${video_name}* || "$RESPONSE_BODY" != *${audio_name}* || "$RESPONSE_BODY" != *${pdf_name}* ]]; then
         echo "[ $SERVICE_NAME ] Content does not match the expected result: $RESPONSE_BODY"
         docker logs test-comps-dataprep-multimodal-redis >> ${LOG_PATH}/dataprep_file.log
         exit 1


### PR DESCRIPTION
## Description

This adds PDF ingestion capability to the MultimodalQnA dataprep service. It extracts images and text appearing on the same page together, embeds them with BridgeTower, and stores the results in redis. This uses a new external dependency `pymupdf` and goes with this [frontend PR in GenAIExamples](https://github.com/mhbuehler/GenAIExamples/pull/32).

## Issues

[RFC](https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md)

## Type of change

- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

New dependency for MMQnA: `pymupdf`

## Tests

There is a new test in `tests/dataprep/test_dataprep_multimodal_redis_langchain.sh` and new tests in the [PR for GenAIExamples MultimodalQnA](https://github.com/mhbuehler/GenAIExamples/pull/32).
