### PR TITLE
Fixed download link of test file in multimodal dataprep test

### DIFF
--- a/tests/dataprep/test_dataprep_multimodal_redis_langchain.sh
+++ b/tests/dataprep/test_dataprep_multimodal_redis_langchain.sh
@@ -135,7 +135,7 @@ tire.""" > ${transcript_fn}
     wget https://github.com/intel/intel-extension-for-transformers/raw/main/intel_extension_for_transformers/neural_chat/assets/audio/sample.wav -O ${audio_fn}
 
     echo "Downloading PDF"
-    wget https://raw.githubusercontent.com/opea-project/GenAIComps/main/comps/retrievers/redis/data/nke-10k-2023.pdf -O ${pdf_fn}
+    wget https://raw.githubusercontent.com/opea-project/GenAIComps/v1.1/comps/retrievers/redis/data/nke-10k-2023.pdf -O ${pdf_fn}
 
 }
 


### PR DESCRIPTION
## Description

Switched the test file to a permanent v1.1 link

## Issues

[RFC](https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

N/A

## Tests

This should fix `test_dataprep_multimodal_redis_langchain.sh`