### PR TITLE
Revert ASR Configurability change

### DIFF
--- a/comps/asr/src/opea_asr_microservice.py
+++ b/comps/asr/src/opea_asr_microservice.py
@@ -34,7 +34,7 @@ loader = OpeaComponentLoader(asr_component_name, description=f"OPEA ASR Componen
     service_type=ServiceType.ASR,
     endpoint="/v1/audio/transcriptions",
     host="0.0.0.0",
-    port=int(os.getenv("ASR_PORT", 9099)),
+    port=9099,
     input_datatype=Base64ByteStrDoc,
     output_datatype=LLMParamsDoc,
 )


### PR DESCRIPTION
## Description

Revert the ASR configurability change as ASR is no longer needed

## Issues

Addressing review comment from https://github.com/opea-project/GenAIComps/pull/1134/files

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A

## Tests

N/A