### PR TITLE
Revert configurable internal whisper port

### DIFF
--- a/comps/asr/src/integrations/dependency/whisper/whisper_server.py
+++ b/comps/asr/src/integrations/dependency/whisper/whisper_server.py
@@ -106,7 +106,7 @@ async def audio_transcriptions(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", type=str, default="0.0.0.0")
-    parser.add_argument("--port", type=int, default=os.getenv("WHISPER_PORT", 7066))
+    parser.add_argument("--port", type=int, default=7066)
     parser.add_argument("--model_name_or_path", type=str, default="openai/whisper-small")
     parser.add_argument("--language", type=str, default="english")
     parser.add_argument("--device", type=str, default="cpu")


### PR DESCRIPTION
## Description

This PR is based on a comment made in the GenAIComps PR. We really only need the external port to be configurable. We can hold on merging this until we hear back to Melanie's comment in the PR.

## Issues

https://github.com/opea-project/GenAIComps/pull/1134#discussion_r1912621402

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A

## Tests

Tested by using a different port externally vs internally:

```
$ docker ps
33ca0dedbfef   opea/whisper:latest                            "python whisper_serv…"   7 minutes ago   Up 7 minutes             0.0.0.0:7044->7066/tcp                           whisper-service
...

$ echo $WHISPER_SERVER_ENDPOINT
http://10.165.116.7:7044/v1/asr

$ curl ${WHISPER_SERVER_ENDPOINT}     -X POST     -H "Content-Type: application/json"     -d '{"audio" : "UklGRigAAABXQVZFZm10IBIAAAABAAEARKwAAIhYAQACABAAAABkYXRhAgAAAAEA"}'
{"asr_result":"you"}
```
