### PR TITLE
Added audio dict field to ChatMessage and modalities to ChatCompletionRequest

### DIFF
--- a/comps/cores/proto/api_protocol.py
+++ b/comps/cores/proto/api_protocol.py
@@ -156,6 +156,7 @@ class ChatCompletionRequest(BaseModel):
         List[Dict[str, Union[str, List[Dict[str, Union[str, Dict[str, str]]]]]]],
     ]
     model: Optional[str] = None
+    modalities: List[Literal["text", "audio"]] = Field(default=["text"])
     frequency_penalty: Optional[float] = 0.0
     logit_bias: Optional[Dict[str, float]] = None
     logprobs: Optional[bool] = False
@@ -349,7 +350,6 @@ class ChatCompletionResponse(BaseModel):
     object: str = "chat.completion"
     created: int = Field(default_factory=lambda: int(time.time()))
     model: str
-    modalities: List[Literal["text", "audio"]] = Field(default=["text"])
     choices: List[ChatCompletionResponseChoice]
     usage: UsageInfo
 

--- a/comps/cores/proto/api_protocol.py
+++ b/comps/cores/proto/api_protocol.py
@@ -335,6 +335,7 @@ class AudioSpeechRequest(BaseModel):
 class ChatMessage(BaseModel):
     role: str
     content: str
+    audio: Optional[Dict[str, Any]] = None
 
 
 class ChatCompletionResponseChoice(BaseModel):

--- a/comps/cores/proto/api_protocol.py
+++ b/comps/cores/proto/api_protocol.py
@@ -337,7 +337,6 @@ class ChatMessage(BaseModel):
     content: str
     audio: Optional[Dict[str, Any]] = None
 
-
 class ChatCompletionResponseChoice(BaseModel):
     index: int
     message: ChatMessage
@@ -350,6 +349,7 @@ class ChatCompletionResponse(BaseModel):
     object: str = "chat.completion"
     created: int = Field(default_factory=lambda: int(time.time()))
     model: str
+    modalities: List[Literal["text", "audio"]] = Field(default=["text"])
     choices: List[ChatCompletionResponseChoice]
     usage: UsageInfo
 


### PR DESCRIPTION
## Description

Added an audio dictionary to `ChatMessage` as we will now need a place to store TTS output. Also added `modalities` attribute as a way to toggle on/off the use of TTS. These changes are consistent with the OpenAI docs ([see here](https://platform.openai.com/docs/api-reference/chat/create#chat-create-audio)), OPEA just had a more simplified version.
## Issues

https://github.com/opea-project/GenAIExamples/issues/1549

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A

## Tests

Manually tested by rebuilding mmqna dockerfile, running curl commands