### PR TITLE
Update the redis multimodal dataprep microservice to support ingestion for an image with a spoken audio caption

### DIFF
--- a/comps/dataprep/src/README_multimodal.md
+++ b/comps/dataprep/src/README_multimodal.md
@@ -116,9 +116,9 @@ Once this dataprep microservice is started, user can use the below commands to i
 
 This microservice provides 3 different ways for users to ingest files into Redis vector store corresponding to the 3 use cases.
 
-### 4.1 Consume _ingest_with_text_ API
+### 4.1 Consume _ingest_ API
 
-**Use case:** This API is used for videos accompanied by transcript files (`.vtt` format), images accompanied by text caption files (`.txt` format), and PDF files containing a mix of text and images.
+**Use case:** This API is used for videos accompanied by transcript files (`.vtt` format), images accompanied by text caption files (`.txt` format), images accompanied by a spoken audio caption (`.wav` or `.mp3`), and PDF files containing a mix of text and images.
 
 **Important notes:**
 
@@ -138,11 +138,27 @@ curl -X POST \
 
 #### Single image-caption pair upload
 
+Text caption file:
+
 ```bash
 curl -X POST \
     -H "Content-Type: multipart/form-data" \
     -F "files=@./image.jpg" \
     -F "files=@./image.txt" \
+    http://localhost:6007/v1/dataprep/ingest
+```
+
+Spoken audio caption file:
+
+> Note: When an audio caption file is provided, the speech is translated to text using the
+> [whisper model](https://openai.com/index/whisper/). The translated text is then embedded with the image, and ingested
+> into the vector store.
+
+```bash
+curl -X POST \
+    -H "Content-Type: multipart/form-data" \
+    -F "files=@./image.jpg" \
+    -F "files=@./image.wav" \
     http://localhost:6007/v1/dataprep/ingest
 ```
 

--- a/comps/dataprep/src/integrations/redis_multimodal.py
+++ b/comps/dataprep/src/integrations/redis_multimodal.py
@@ -682,6 +682,9 @@ class OpeaMultimodalRedisDataprep(OpeaComponent):
                 elif file_extension not in accepted_media_formats:
                     logger.info(f"Skipping file {file.filename} because of unsupported format.")
 
+                if file_extension in audio_formats:
+                    audio_caption_exists = True
+
             # Check that every media file that is not a pdf has a caption file
             for media_file_name, file_list in matched_files.items():
                 if len(file_list) != 2 and os.path.splitext(media_file_name)[1] != ".pdf":

--- a/comps/dataprep/src/integrations/redis_multimodal.py
+++ b/comps/dataprep/src/integrations/redis_multimodal.py
@@ -693,7 +693,7 @@ class OpeaMultimodalRedisDataprep(OpeaComponent):
             if len(matched_files.keys()) == 0:
                 return HTTPException(
                     status_code=400,
-                    detail="The uploaded files have unsupported formats. Please upload at least one video file (.mp4) with captions (.vtt) or one image (.png, .jpg, .jpeg, or .gif) with caption (.txt) or one .pdf file",
+                    detail="The uploaded files have unsupported formats. Please upload at least one video file (.mp4) with captions (.vtt) or one image (.png, .jpg, .jpeg, or .gif) with caption (.txt, .mp3, or .wav) or one .pdf file",
                 )
 
             # Load whisper model to translate audio caption for images
@@ -814,7 +814,7 @@ class OpeaMultimodalRedisDataprep(OpeaComponent):
 
         raise HTTPException(
             status_code=400,
-            detail="Must provide at least one pair consisting of video (.mp4) and captions (.vtt) or image (.png, .jpg, .jpeg, .gif) with caption (.txt)",
+            detail="Must provide at least one pair consisting of video (.mp4) and captions (.vtt) or image (.png, .jpg, .jpeg, .gif) with caption (.txt, .mp3, or .wav)",
         )
 
     async def get_files(self):

--- a/tests/dataprep/test_dataprep_redis_multimodal.sh
+++ b/tests/dataprep/test_dataprep_redis_multimodal.sh
@@ -15,11 +15,11 @@ tmp_dir=$(mktemp -d)
 video_name="WeAreGoingOnBullrun"
 transcript_fn="${tmp_dir}/${video_name}.vtt"
 video_fn="${tmp_dir}/${video_name}.mp4"
-audio_name="AudioSample"
-audio_fn="${tmp_dir}/${audio_name}.wav"
 image_name="apple"
 image_fn="${tmp_dir}/${image_name}.png"
 caption_fn="${tmp_dir}/${image_name}.txt"
+audio_name="apple"   # Intentionally name the audio file the same as the image for testing image+audio caption
+audio_fn="${tmp_dir}/${audio_name}.wav"
 pdf_name="nke-10k-2023"
 pdf_fn="${tmp_dir}/${pdf_name}.pdf"
 DATAPREP_PORT="11109"
@@ -125,7 +125,7 @@ place to watch it is on BlackmagicShine.com. We're right here on the smoking
 00:00:45.240 --> 00:00:47.440
 tire.""" > ${transcript_fn}
 
-    echo "This is an apple."  > ${caption_fn}
+    echo "This is an apple." > ${caption_fn}
 
     echo "Downloading Image"
     wget https://github.com/docarray/docarray/blob/main/tests/toydata/image-data/apple.png?raw=true -O ${image_fn}
@@ -191,11 +191,35 @@ function validate_microservice() {
         echo "[ $SERVICE_NAME ] Content is as expected."
     fi
 
-    # test ingest upload image file
-    echo "Testing ingest API with image+caption"
+    # test ingest upload image file with text caption
+    echo "Testing ingest API with image+text caption"
     URL="http://${ip_address}:$DATAPREP_PORT/v1/dataprep/ingest"
 
     HTTP_RESPONSE=$(curl --silent --write-out "HTTPSTATUS:%{http_code}" -X POST -F "files=@$image_fn" -F "files=@$caption_fn" -H 'Content-Type: multipart/form-data' "$URL")
+    HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+    RESPONSE_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
+    SERVICE_NAME="dataprep - upload - file"
+
+    if [ "$HTTP_STATUS" -ne "200" ]; then
+        echo "[ $SERVICE_NAME ] HTTP status is not 200. Received status was $HTTP_STATUS"
+        docker logs dataprep-multimodal-redis-server >> ${LOG_PATH}/dataprep_upload_file.log
+        exit 1
+    else
+        echo "[ $SERVICE_NAME ] HTTP status is 200. Checking content..."
+    fi
+    if [[ "$RESPONSE_BODY" != *"Data preparation succeeded"* ]]; then
+        echo "[ $SERVICE_NAME ] Content does not match the expected result: $RESPONSE_BODY"
+        docker logs dataprep-multimodal-redis-server >> ${LOG_PATH}/dataprep_upload_file.log
+        exit 1
+    else
+        echo "[ $SERVICE_NAME ] Content is as expected."
+    fi
+
+    # test ingest upload image file with audio caption
+    echo "Testing ingest API with image+audio caption"
+    URL="http://${ip_address}:$DATAPREP_PORT/v1/dataprep/ingest"
+
+    HTTP_RESPONSE=$(curl --silent --write-out "HTTPSTATUS:%{http_code}" -X POST -F "files=@$image_fn" -F "files=@$audio_fn" -H 'Content-Type: multipart/form-data' "$URL")
     HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
     RESPONSE_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
     SERVICE_NAME="dataprep - upload - file"


### PR DESCRIPTION
## Description

This PR has backend support for the image + audio data ingestion feature for MultimodalQnA. It updates the redis multimodal data prep microservice's `ingest` endpoint to allow passing an image file with a spoken audio file (`.wav` or `.mp3`). This works very similarly to the image + text caption ingestion, except that there's an extra step to convert the audio to text using the whisper model.

I have added a test for image + audio ingestion and updated the README for the redis multimodal data prep microservice. 

## Issues

RFC: https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md
Issue: https://github.com/opea-project/GenAIExamples/issues/1549

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

None

## Tests

Ran all test_dataprep_redis_mutimodal tests, and added a new test.
