### PR TITLE
Fixes unintended color channel swap

### DIFF
--- a/comps/dataprep/src/integrations/redis_multimodal.py
+++ b/comps/dataprep/src/integrations/redis_multimodal.py
@@ -635,7 +635,7 @@ class OpeaMultimodalRedisDataprep(OpeaComponent):
                 self.ingest_multimodal(name, os.path.join(self.upload_folder, dir_name), self.embeddings)
 
                 # Delete temporary directory containing frames and annotations
-                # shutil.rmtree(os.path.join(upload_folder, dir_name))
+                shutil.rmtree(os.path.join(upload_folder, dir_name))
 
                 logger.info(f"Processed file {file.filename}")
 

--- a/comps/dataprep/src/integrations/utils/multimodal.py
+++ b/comps/dataprep/src/integrations/utils/multimodal.py
@@ -246,13 +246,14 @@ def use_lvm(endpoint: str, img_b64_string: str, prompt: str = "Provide a short d
 def extract_frames_and_generate_captions(
     video_id: str, video_path: str, lvm_endpoint: str, output_dir: str, key_frame_per_second: int = 1
 ):
-    """Extract frames (.png) and annotations (.json) from video file (.mp4) by generating captions using LVM microservice."""
+    """Extract frames (.png) and annotations (.json) from video file (.mp4). This works for still images (.png, .jpg, .jpeg, .gif)
+    too, using the cv2 library. Captions are generated using the LVM microservice."""
     # Set up location to store frames and annotations
     os.makedirs(output_dir, exist_ok=True)
     os.makedirs(os.path.join(output_dir, "frames"), exist_ok=True)
     is_video = os.path.splitext(video_path)[-1] == ".mp4"
 
-    # Load video and get fps
+    # Load file and get fps
     vidcap = cv2.VideoCapture(video_path)
     fps = vidcap.get(cv2.CAP_PROP_FPS)
 
@@ -273,7 +274,9 @@ def extract_frames_and_generate_captions(
             mid_time_ms = mid_time  # Already in ms
 
             frame_no = curr_frame
-            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            # Reorder the color channels for video but not for images
+            if is_video:
+                frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
 
             # Save frame for further processing
             img_fname = f"frame_{idx}"

--- a/comps/dataprep/src/integrations/utils/multimodal.py
+++ b/comps/dataprep/src/integrations/utils/multimodal.py
@@ -274,9 +274,6 @@ def extract_frames_and_generate_captions(
             mid_time_ms = mid_time  # Already in ms
 
             frame_no = curr_frame
-            # Reorder the color channels for video but not for images
-            if is_video:
-                frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
 
             # Save frame for further processing
             img_fname = f"frame_{idx}"


### PR DESCRIPTION
## Description

This fixes a bug that was found in the multimodal dataprep microservice's ingestion of images and videos. It was using a color channel switch operation (BGR -> RGB) that was not needed. Goes with https://github.com/mhbuehler/GenAIExamples/pull/57.

## Issues

[RFC](https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

N/A

## Tests

I manually tested this by ingesting an image of a red apple that was previously being saved with blue appearance and consistently being described by the LVM as blue. I then queried for an apple and asked what color it is. After a fresh ingestion, the megaservice correctly identifies the color as red now. I've updated a [test in GenAIExamples](https://github.com/mhbuehler/GenAIExamples/pull/57) to perform this same query and verify that the response contains the word "red". 

(Note: Per @dmsuehir 's suggestion, I looked at the saved frames of .mp4 videos and .png files using both transcription generation and caption generation and after completely deleting the channel swap operation, all variants now look correct.)