### PR TITLE
Fix data ingestion with jpg and audio caption

### DIFF
--- a/comps/dataprep/src/integrations/redis_multimodal.py
+++ b/comps/dataprep/src/integrations/redis_multimodal.py
@@ -774,18 +774,17 @@ class OpeaMultimodalRedisDataprep(OpeaComponent):
                     with open(os.path.join(self.upload_folder, caption_file), "wb") as f:
                         shutil.copyfileobj(matched_files[media_file][1].file, f)
 
-                    # If caption file is an audio format, get the transcription
+                    # If caption file is an audio format, get the transcription and write a .txt caption file
                     if caption_file_extension in audio_formats:
-                        # Get the transcript from the audio and write a vtt file
                         transcripts = extract_transcript_from_audio(whisper_model, os.path.join(self.upload_folder, caption_file))
-                        vtt_file = f"{media_dir_name}.vtt"
-                        write_vtt(transcripts, os.path.join(self.upload_folder, vtt_file))
+                        caption_text = ""
 
-                        # Delete the temporary audio
-                        os.remove(os.path.join(self.upload_folder, caption_file))
+                        if transcripts and "text" in transcripts:
+                            caption_text = transcripts["text"]
 
-                        # After this, the caption file is the vtt file
-                        caption_file = vtt_file
+                        caption_file = f"{media_dir_name}.txt"
+                        with open(os.path.join(self.upload_folder, caption_file), "w") as f:
+                            f.write(caption_text)
 
                     # Store frames and caption annotations in a new directory
                     extract_frames_and_annotations_from_transcripts(


### PR DESCRIPTION
## Description

This PR fixes an issue where data ingestion with jpg/jpeg files with an audio file was failing. It seems to be an issue with using .vtt files with jpg/jpeg files with cv2. The [`vidcap.read()`](https://github.com/mhbuehler/GenAIComps/blob/7a7fd9b5ca8124ac6b9ed511317324f0fb12fdc7/comps/dataprep/src/integrations/utils/multimodal.py#L207) call was returning False, so we weren't getting any frames from the jpg. When changing the transcription format from .vtt to .txt (which is the same thing that would be used for image + text ingestion), it works as expected.

## Issues

Image + audio ingestion was failing when the image was a jpg/jpeg file.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

None

## Tests

Added a new test for jpg + audio ingestion
