### PR TITLE
Workaround bad setuptools release

### DIFF
--- a/comps/dataprep/src/Dockerfile
+++ b/comps/dataprep/src/Dockerfile
@@ -32,7 +32,7 @@ RUN useradd -m -s /bin/bash user && \
 
 COPY comps /home/user/comps
 
-RUN pip install --no-cache-dir --upgrade pip setuptools && \
+RUN pip install --no-cache-dir --upgrade pip setuptools==77.0.3 && \
     if [ ${ARCH} = "cpu" ]; then \
         PIP_EXTRA_INDEX_URL="--extra-index-url https://download.pytorch.org/whl/cpu"; \
     else \


### PR DESCRIPTION
## Description

The latest version setuptools removed some deprecated config, but the data prep Dockerfile uses some third party libraries which are still using that deprecated config, so it :boom: when that functionality was removed. In the issue being tracked in the setuptools repo, it looks like they are working to put back those deprecated configs because it's affecting a lot of people. Until that happens, this PR is using the previous version of setuptools so that the CI will run on our branch.

## Issues

https://github.com/opea-project/GenAIComps/issues/1449

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

N/A

## Tests

Locally built the docker image
