### PR TITLE
Fix docker logs container name in ASR HPU test file

### DIFF
--- a/tests/asr/test_asr_whisper_on_intel_hpu.sh
+++ b/tests/asr/test_asr_whisper_on_intel_hpu.sh
@@ -60,8 +60,8 @@ function validate_microservice() {
         echo "Result correct."
     else
         echo "Result wrong."
-        docker logs whisper-service
-        docker logs asr-service
+        docker logs whisper-gaudi-service
+        docker logs asr-whisper-gaudi-service
         exit 1
     fi
 


### PR DESCRIPTION
## Description

This PR corrects the container name in the `docker log` commands in the ASR Gaudi tests. This was something that was commented on in our upstream PR. 

## Issues

https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

None

## Tests

Test fix
