### PR TITLE
Update redis multimodal dataprep text only pdf test to use local file

### DIFF
--- a/tests/dataprep/ingest_dataprep_text.pdf
+++ b/tests/dataprep/ingest_dataprep_text.pdf
@@ -1,0 +1,52 @@
+%PDF-1.7
+%µ¶
+
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+
+2 0 obj
+<</Type/Pages/Count 1/Kids[4 0 R]>>
+endobj
+
+3 0 obj
+<</Font<</helv 5 0 R>>>>
+endobj
+
+4 0 obj
+<</Type/Page/MediaBox[0 0 595 842]/Rotate 0/Resources 3 0 R/Parent 2 0 R/Contents[6 0 R]>>
+endobj
+
+5 0 obj
+<</Type/Font/Subtype/Type1/BaseFont/Helvetica/Encoding/WinAnsiEncoding>>
+endobj
+
+6 0 obj
+<</Length 74>>
+stream
+
+q
+BT
+1 0 0 1 50 792 Tm
+/helv 11 Tf [<54657874206f6e6c7920504446>]TJ
+ET
+Q
+
+endstream
+endobj
+
+xref
+0 7
+0000000000 65535 f 
+0000000016 00000 n 
+0000000062 00000 n 
+0000000114 00000 n 
+0000000155 00000 n 
+0000000262 00000 n 
+0000000351 00000 n 
+
+trailer
+<</Size 7/Root 1 0 R/ID[<C2A52BC29974770DC3A8C381C3917FC2><7AAC17B8B9946850110889D7AA64AA51>]>>
+startxref
+474
+%%EOF

--- a/tests/dataprep/test_dataprep_redis_multimodal.sh
+++ b/tests/dataprep/test_dataprep_redis_multimodal.sh
@@ -23,6 +23,7 @@ audio_name="apple"   # Intentionally name the audio file the same as the image f
 audio_fn="${tmp_dir}/${audio_name}.wav"
 pdf_name="nke-10k-2023"
 pdf_fn="${tmp_dir}/${pdf_name}.pdf"
+text_ony_pdf_fn="${WORKPATH}/tests/dataprep/ingest_dataprep_text.pdf"
 DATAPREP_PORT="11109"
 export DATA_PATH=${model_cache}
 
@@ -143,14 +144,6 @@ tire.""" > ${transcript_fn}
 
     echo "Downloading PDF"
     wget https://raw.githubusercontent.com/opea-project/GenAIComps/v1.1/comps/retrievers/redis/data/nke-10k-2023.pdf -O ${pdf_fn}
-
-    echo "Creating a text-only pdf file"
-    docker run --rm -e http_proxy=$http_proxy -e https_proxy=$https_proxy -v "$tmp_dir:/mnt" python:latest bash -c " \
-        pip install pymupdf && \
-        python -c \"import fitz; new_pdf = fitz.open(); page = new_pdf.new_page(); page.insert_text(point=(50, 50), text='Text only PDF'); \
-        new_pdf.save('/mnt/test.pdf'); new_pdf.close()\"
-    "
-
 }
 
 function validate_microservice() {
@@ -348,11 +341,10 @@ function validate_microservice() {
     fi
 
     # test ingest with a text-only PDF file
-    pdf_fn="${tmp_dir}/test.pdf"
     echo "Testing ingest API with a text-only PDF file"
     URL="http://${ip_address}:$DATAPREP_PORT/v1/dataprep/ingest"
 
-    HTTP_RESPONSE=$(curl --silent --write-out "HTTPSTATUS:%{http_code}" -X POST -F "files=@$pdf_fn" -H 'Content-Type: multipart/form-data' "$URL")
+    HTTP_RESPONSE=$(curl --silent --write-out "HTTPSTATUS:%{http_code}" -X POST -F "files=@$text_ony_pdf_fn" -H 'Content-Type: multipart/form-data' "$URL")
     HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
     RESPONSE_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
     SERVICE_NAME="dataprep - upload - file"


### PR DESCRIPTION
## Description

It seems like it's the text only PDF test that is commonly failing with the `000` http status error (it also sometimes passes). We were generating a PDF on the fly in a docker container and I'm wondering if that could be creating a permissions issue (the file created in the container is owned by root). Not sure why it would sometimes pass and sometimes fail, it could be machine dependent - it passes for me locally.

This PR instead adds the text only file to the repo. There is already a precedent for doing this (they have other test files like `ingest_dataprep.pdf`, `ingest_dataprep.txt`, etc).

## Issues

[RFC](https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

Ran tests locally on xeon
